### PR TITLE
Display time in 24 hour rather than 12 hour format

### DIFF
--- a/src/Views/NewAssessment.js
+++ b/src/Views/NewAssessment.js
@@ -344,7 +344,7 @@ class NewAssessment extends React.Component {
                                 <Datetime onChange={this.onChange.bind(this)}
                                           value={this.state.date}
                                           dateFormat='DD/MM/YYYY'
-                                          timeFormat='hh:mm:ss'/>
+                                          timeFormat='HH:mm:ss'/>
                                 {/*<DatePicker
                                     onChange={this.onChange.bind(this)}
                                     value={this.state.date}


### PR DESCRIPTION
The 12 hour format for time meant that the only way to change things was with the datepicker.